### PR TITLE
A compendium of fixes for sockets and multiprocessing.

### DIFF
--- a/acl-compat/acl-compat.asd
+++ b/acl-compat/acl-compat.asd
@@ -99,7 +99,7 @@ lisp-system"))
 (defsystem acl-compat
     :name "acl-compat"
     :author "The acl-compat team"
-    :version "0.2.0"
+    :version "0.3.0"
     :description
     "A reimplementation of parts of the ACL API, mainly to get
     AllegroServe running on various machines, but might be useful

--- a/acl-compat/acl-compat.asd
+++ b/acl-compat/acl-compat.asd
@@ -124,9 +124,13 @@ lisp-system"))
      (:unportable-cl-source-file "acl-mp"
                                  :depends-on ("packages" #+(or mcl openmcl) "mcl-timers"))
      ;; Sockets, networking; TODO: de-frob this a bit
+     #+sbcl
+     (:unportable-cl-source-file
+      "socket-streams" :depends-on ("packages"))
      #-(or mcl openmcl)
      (:unportable-cl-source-file
       "acl-socket" :depends-on ("packages" "acl-excl"
+                                           #+sbcl "socket-streams"
                                            #-(or allegro (and mcl (not openmcl))) "chunked-stream-mixin"))
      #+(and mcl (not openmcl))
      (:unportable-cl-source-file "acl-socket-mcl" :depends-on ("packages"))

--- a/acl-compat/acl-compat.asd
+++ b/acl-compat/acl-compat.asd
@@ -122,10 +122,16 @@ lisp-system"))
      (:legacy-cl-source-file "chunked-stream-mixin"
                              :depends-on ("packages" "acl-excl"
                                                      #-lispworks "lw-buffering"))
-     ;; Multiprocessing
+     ;; Multi
+
+
+
+
+processing
+     (:file "mp-decls" (:depends-on "packages"))
      #+(or mcl openmcl) (:unportable-cl-source-file "mcl-timers")
      (:unportable-cl-source-file "acl-mp"
-                                 :depends-on ("packages" #+(or mcl openmcl) "mcl-timers"))
+                                 :depends-on ("packages" "mp-decls" #+(or mcl openmcl) "mcl-timers"))
      ;; Sockets, networking; TODO: de-frob this a bit
      #+sbcl
      (:unportable-cl-source-file

--- a/acl-compat/acl-compat.asd
+++ b/acl-compat/acl-compat.asd
@@ -4,6 +4,9 @@
 ;;;; acl-compat-cmu.system, but could replace all other systems, too.
 ;;;; (hint, hint)
 
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (asdf:load-system :fiveam-asdf))
+
 (defpackage #:acl-compat-system
   (:use #:cl #:asdf))
 (in-package #:acl-compat-system)
@@ -164,3 +167,9 @@ lisp-system"))
                  )
     :perform (load-op :after (op acl-compat)
                       (pushnew :acl-compat cl:*features*)))
+
+(defsystem acl-compat/acl-socket-tester
+  :class fiveam-tester-system
+  :depends-on ("acl-compat")
+  :test-names ((acl-socket-tests . acl-socket-tests))
+  :components ((:file "test-acl-socket")))

--- a/acl-compat/acl-excl-common.lisp
+++ b/acl-compat/acl-excl-common.lisp
@@ -105,9 +105,9 @@
 (defun filesys-write-date (stream)
   (file-write-date stream))
 
-(defun acl-compat.system:make-temp-file-name (name)
-  (cl-fad:with-open-temporary-file (s)
-    (pathname s)))
+(defun acl-compat.system:make-temp-file-name (&optional prefix (directory (uiop:temporary-directory)))
+  (namestring (uiop:tmpize-pathname (make-pathname :directory (pathname-directory directory)
+                                                   :name prefix))))
 
 (defun frob-regexp (regexp)
   "This converts from ACL regexps to Perl regexps.  The escape
@@ -203,6 +203,7 @@ program-controlled interception of a break."
   (ironclad:make-digest :md5))
 
 (defun md5-update (context data &rest args &key start end external-format)
+  (declare (ignore start end external-format))
   (apply #'ironclad:update-digest context data args))
 
 (defun md5-final (context &key (return :integer))
@@ -214,9 +215,8 @@ program-controlled interception of a break."
       (:hex (ironclad:byte-array-to-hex-string result)))))
 
 (defun rename-file-raw (filespec new-name &key follow-symlinks)
-  (let ((expanded (merge-pathnames (parse-namestring new-name))))
-    (multiple-value-bind (defaulted-new-name old-truename new-truename)
-        (rename-file filespec expanded)
-      (if follow-symlinks
-          new-name
-          new-truename))))
+  (let* ((expanded (merge-pathnames (parse-namestring new-name)))
+         (new-truename (nth-value 2 (rename-file filespec expanded))))
+    (if follow-symlinks
+        new-name
+        new-truename)))

--- a/acl-compat/mcl/acl-mp.lisp
+++ b/acl-compat/mcl/acl-mp.lisp
@@ -6,37 +6,7 @@
 
 (in-package :acl-compat.mp)
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
 
-; existing stuff from ccl we can reuse directly
-(shadowing-import 
- '(ccl:*current-process*
-   ccl::lock
-   ccl:process-allow-schedule
-   ccl:process-name
-   ccl:process-preset
-   #-openmcl-native-threads ccl:process-run-reasons
-   ccl:process-wait
-   ccl:process-wait-with-timeout
-   ccl:without-interrupts))
-)
-
-(eval-when (:compile-toplevel :load-toplevel :execute)
-
-(export 
- '(*current-process*
-   lock
-   process-allow-schedule
-   process-name
-   process-preset
-   process-run-reasons
-   process-wait
-   process-wait-with-timeout
-   without-interrupts))
-)
-
-(eval-when (:compile-toplevel :load-toplevel :execute)
-                 
 (defmacro without-scheduling (&body forms)
   `(ccl:without-interrupts ,@forms))
 
@@ -46,7 +16,7 @@
   (block timeout
     (let* ((process *current-process*)
            (timer (ccl:process-run-function "with-timeout-timer"
-                                            #'(lambda () 
+                                            #'(lambda ()
                                                 (sleep seconds)
                                                 (ccl:process-interrupt process
                                                                        #'(lambda ()
@@ -66,7 +36,7 @@
                     #'(lambda () (return-from timeout (funcall timeoutfn))))))
       (ccl::enqueue-timer-request timer)
       (unwind-protect (funcall bodyfn)
-	(ccl::dequeue-timer-request timer)))))
+        (ccl::dequeue-timer-request timer)))))
 
 
 (defmacro with-timeout ((seconds &body timeout-forms) &body body)
@@ -91,9 +61,9 @@
            (eq (car initial-bindings) 'quote))
     (cadr initial-bindings)
     initial-bindings))
-                             
+
 )
-	   
+
 
 #-openmcl-native-threads
 (defmacro process-revoke-run-reason (process reason)
@@ -120,7 +90,7 @@
      (unless (ccl:process-active-p ,process) ;won't die unless enabled
        (ccl:process-reset-and-enable ,process) )
      (ccl:process-kill ,process)))
-)
+
 
 (defun process-active-p (process)
   (ccl::process-active-p process))
@@ -176,7 +146,7 @@ See the functions process-plist, (setf process-plist).")
     (flet ((collect-fds ()
              (setf collected-fds
                    (remove-if-not wait-function streams))))
-      
+
       (if timeout
           (process-wait-with-timeout (or whostate "Waiting for input") timeout #'collect-fds)
           (process-wait (or whostate "Waiting for input") #'collect-fds)))

--- a/acl-compat/mcl/acl-mp.lisp
+++ b/acl-compat/mcl/acl-mp.lisp
@@ -151,3 +151,8 @@ See the functions process-plist, (setf process-plist).")
           (process-wait-with-timeout (or whostate "Waiting for input") timeout #'collect-fds)
           (process-wait (or whostate "Waiting for input") #'collect-fds)))
     collected-fds))
+
+(defun process-wait-with-timeout (whostate seconds function &rest args)
+  ;; correct the seconds value to ticks for CCL:PROCESS-WAIT-WITH-TIMEOUT
+  (let ((ticks (round (* seconds ccl:*ticks-per-second*))))
+    (apply #'ccl:process-wait-with-timeout whostate ticks function args)))

--- a/acl-compat/packages.lisp
+++ b/acl-compat/packages.lisp
@@ -74,6 +74,7 @@
   #+allegro (:shadowing-import-from :mp #:process-interrupt #:lock)
   #+allegro (:shadowing-import-from :excl #:without-interrupts)
   (:export
+   #:*all-processes*
    #:*current-process*         ;*
    #:process-kill              ;*
    #:process-preset            ;*
@@ -118,6 +119,27 @@
   (:export #:chunked-stream-mixin
            #:output-chunking-p #:input-chunking-p))
 
+#+sbcl
+(defpackage socket-streams
+  (:use common-lisp sb-gray)
+  (:import-from #:sb-bsd-sockets #:socket #:socket-peername #:inet-socket)
+  ;; intern this here to avoid required forward reference
+  ;; into acl-compat.socket
+  (:intern #:vector-to-ipaddr)
+  (:export #:socket-stream
+           #:socket-input-stream
+           #:socket-output-stream
+           #:socket-text-io-stream
+           #:socket-binary-io-stream
+           #:socket-bivalent-io-stream
+
+           #:socket-stream-socket
+           #:socket-stream-stream
+           #:local-host
+           #:local-port
+           #:remote-host
+           #:remote-port))
+
 ;; general
 (defpackage acl-compat.socket
   (:use #:common-lisp
@@ -125,9 +147,16 @@
         #+(or lispworks cmu)#:acl-compat.excl
         #+clisp #:socket
         #+sbcl #:sb-bsd-sockets
+        #+sbcl #:socket-streams
         #+(or lispworks cmu) #:de.dataheaven.chunked-stream-mixin
         #+cormanlisp #:socket
         )
+  #+sbcl
+  (:shadow #:socket-make-stream)
+  #+sbcl
+  (:import-from #:socket-streams #:vector-to-ipaddr)
+  #+sbcl
+  (:import-from #:sb-bsd-sockets #:socket-peername)
   #+openmcl
   (:shadowing-import-from :ccl
                           #:accept-connection

--- a/acl-compat/packages.lisp
+++ b/acl-compat/packages.lisp
@@ -73,12 +73,21 @@
   (:nicknames :acl-mp #-cormanlisp :acl-compat-mp)
   #+allegro (:shadowing-import-from :mp #:process-interrupt #:lock)
   #+allegro (:shadowing-import-from :excl #:without-interrupts)
+  #+ccl
+  (:shadowing-import-from #:ccl
+   lock
+   process-allow-schedule
+   process-name
+   process-preset
+   #-openmcl-native-threads process-run-reasons
+   process-wait
+   without-interrupts)
   (:export
    #:*all-processes*
-   #:*current-process*         ;*
-   #:process-kill              ;*
-   #:process-preset            ;*
-   #:process-name              ;*
+   #:*current-process*                  ;*
+   #:process-kill                       ;*
+   #:process-preset                     ;*
+   #:process-name                       ;*
 
    #:process-wait-function
    #:process-run-reasons
@@ -91,19 +100,19 @@
    #:process-reset
    #:process-interrupt
 
-   #:process-run-function      ;*
-   #:process-property-list     ;*
-   #:without-scheduling        ;*
-   #:process-allow-schedule    ;*
-   #:make-process              ;*
-   #:process-add-run-reason    ;*
-   #:process-revoke-run-reason ;*
-   #:process-add-arrest-reason    ;*
-   #:process-revoke-arrest-reason ;*
-   #:process-allow-schedule    ;*
-   #:with-timeout              ;*
-   #:make-process-lock         ;*
-   #:with-process-lock         ;*
+   #:process-run-function               ;*
+   #:process-property-list              ;*
+   #:without-scheduling                 ;*
+   #:process-allow-schedule             ;*
+   #:make-process                       ;*
+   #:process-add-run-reason             ;*
+   #:process-revoke-run-reason          ;*
+   #:process-add-arrest-reason          ;*
+   #:process-revoke-arrest-reason       ;*
+   #:process-allow-schedule             ;*
+   #:with-timeout                       ;*
+   #:make-process-lock                  ;*
+   #:with-process-lock                  ;*
    #:process-lock
    #:process-unlock
 
@@ -112,6 +121,9 @@
    #:process-wait-with-timeout
    #:wait-for-input-available
    #:process-active-p
+   ;; Don't love the idea of having CCL-only exports [2025/01/18:rpg]
+   #+ccl #:lock
+   #+ccl #:without-interrupts
    ))
 
 (defpackage :de.dataheaven.chunked-stream-mixin

--- a/acl-compat/sbcl/acl-mp.lisp
+++ b/acl-compat/sbcl/acl-mp.lisp
@@ -139,7 +139,8 @@
         (process-arguments process) arguments)
   (when (process-id process) (restart-process process)))
 
-(defun/sb-thread process-kill (process)
+(defun/sb-thread process-kill (process &key wait)
+  (declare (ignore wait))
   (when (process-id process)
     (sb-thread:terminate-thread (process-id process))
     (setf (process-id process) nil))

--- a/acl-compat/sbcl/socket-streams.lisp
+++ b/acl-compat/sbcl/socket-streams.lisp
@@ -1,0 +1,353 @@
+;;;----------------------------------------------------------------------
+;;; SOCKET-STREAMS for SBCL
+;;; These associate together a socket and a stream derived from that
+;;; socket.
+;;; These are used here because SBCL's SB-BSD-SOCKETS:SOCKET-MAKE-STREAM
+;;; produces a stream that doesn't conveniently make socket information
+;;; available.
+;;;----------------------------------------------------------------------
+
+;;; ---------------------------------------------------------------------------
+;;; Original code from McCLIM: encapsulating-streams.lisp
+;;;   License: LGPL-2.1+ (See file 'Copyright' for details).
+;;; ---------------------------------------------------------------------------
+;;;
+;;;  (c) Copyright 2001 by Tim Moore <moore@bricoworks.com>
+;;;  (c) Copyright 2014 by Robert Strandh <robert.strandh@gmail.com>
+;;;
+;;; ---------------------------------------------------------------------------
+;;;
+(in-package #:socket-streams)
+
+(defclass socket-stream (sb-gray:fundamental-character-stream)
+  ((stream :reader socket-stream-stream :initarg :stream)
+   (socket :reader socket-stream-socket :initarg :socket)))
+
+(defclass socket-input-stream (socket-stream sb-gray:fundamental-character-input-stream)
+  ())
+
+(defclass socket-output-stream (socket-stream
+                                sb-gray:fundamental-character-output-stream)
+  ())
+
+(defclass socket-text-io-stream (socket-stream
+                            sb-gray:fundamental-character-input-stream
+                            sb-gray:fundamental-character-output-stream)
+  ())
+
+(defclass socket-binary-io-stream (socket-stream
+                            sb-gray:fundamental-binary-input-stream
+                            sb-gray:fundamental-binary-output-stream)
+  ())
+
+
+(defclass socket-bivalent-io-stream (socket-text-io-stream
+                                     socket-binary-io-stream)
+  ())
+
+
+
+;;; Macro for defining methods that delegate to the encapsulated
+;;; stream.  Call the delegated method directly if possible, otherwise
+;;; collect up optional and rest args and apply.
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+(defun parse-gf-lambda-list (ll)
+  "Returns the required args, optional args, and presence of rest or key args"
+  (let ((state 'required)
+        (required-args nil)
+        (optional-args nil)
+        (rest-or-key nil))
+    (loop for arg in ll
+          do (cond ((member arg lambda-list-keywords)
+                    (when (or (eq arg '&rest)
+                              (eq arg '&key)
+                              (eq arg '&allow-other-keys))
+                      (setq rest-or-key t)
+                      (loop-finish))
+                    (setq state arg))
+                   ((eq state 'required)
+                    (push arg required-args))
+                   ((eq state '&optional)
+                    (push arg optional-args))
+                   (t (error "How did I get in this lambda list state?~%~
+                              state ~S lambda list ~S"
+                             state ll))))
+    (values (nreverse required-args) (nreverse optional-args) rest-or-key))))
+
+(defmacro def-stream-method (name lambda-list)
+  "stream is a required argument"
+  (multiple-value-bind (required optional rest)
+      (parse-gf-lambda-list lambda-list)
+    (let* ((rest-arg (gensym "REST-ARG"))
+           (supplied-vars (mapcar #'(lambda (var)
+                                      (gensym (format nil "~A-SUPPLIED-P"
+                                                      (symbol-name var))))
+                                  optional))
+           (ll `(,@required
+                 ,@(and optional
+                        `(&optional
+                          ,@(mapcar #'(lambda (var supplied)
+                                        `(,var nil ,supplied))
+                                    optional
+                                    supplied-vars)))
+
+                 ,@(and rest
+                        `(&rest ,rest-arg))))
+           (required-params (mapcar #'(lambda (var)
+                                        (if (consp var)
+                                            (car var)
+                                            var))
+                                    required))
+           (apply-list (gensym "APPLY-LIST"))
+           (body (if (and (not optional) (not rest))
+                     (if (symbolp name)
+                         `(,name ,@required-params)
+                         `(funcall #',name ,@required-params))
+                     `(let ((,apply-list ,(and rest rest-arg)))
+                        ,@(mapcar #'(lambda (var supplied)
+                                      `(when ,supplied
+                                         (push ,var ,apply-list)))
+                                  (reverse optional)
+                                  (reverse supplied-vars))
+                        (apply #',name ,@required-params ,apply-list)))))
+      `(defmethod ,name ,ll
+         (let ((stream (slot-value stream 'stream)))
+           ,body)))))
+
+(defmacro def-socket-method (name lambda-list)
+  "stream is a required argument; socket will be bound and
+invocation delegated to the socket."
+  (multiple-value-bind (required optional rest)
+      (parse-gf-lambda-list lambda-list)
+    (let* ((rest-arg (gensym "REST-ARG"))
+           (supplied-vars (mapcar #'(lambda (var)
+                                      (gensym (format nil "~A-SUPPLIED-P"
+                                                      (symbol-name var))))
+                                  optional))
+           (ll `(,@required
+                 ,@(and optional
+                        `(&optional
+                          ,@(mapcar #'(lambda (var supplied)
+                                        `(,var nil ,supplied))
+                                    optional
+                                    supplied-vars)))
+
+                 ,@(and rest
+                        `(&rest ,rest-arg))))
+           (required-params (mapcar #'(lambda (var)
+                                        (if (consp var)
+                                            (car var)
+                                            var))
+                                    required))
+           (apply-list (gensym "APPLY-LIST"))
+           (body (if (and (not optional) (not rest))
+                     (if (symbolp name)
+                         `(,name ,@required-params)
+                         `(funcall #',name ,@required-params))
+                     `(let ((,apply-list ,(and rest rest-arg)))
+                        ,@(mapcar #'(lambda (var supplied)
+                                      `(when ,supplied
+                                         (push ,var ,apply-list)))
+                                  (reverse optional)
+                                  (reverse supplied-vars))
+                        (apply #',name ,@required-params ,apply-list)))))
+      `(defmethod ,name ,ll
+         (let ((socket (slot-value stream 'socket)))
+           ,(subst 'socket 'stream body))))))
+
+;;; The basic input and output stream protocols, as specified by the Gray
+;;; stream proposal in Chapter Common Lisp Streams .
+
+;;; Not yet, apparently
+#+nil
+(def-stream-method streamp ((stream standard-encapsulating-stream)))
+
+(def-stream-method input-stream-p
+    ((stream socket-stream)))
+
+(def-stream-method output-stream-p
+    ((stream socket-stream)))
+
+(def-stream-method stream-element-type
+    ((stream socket-stream)))
+
+(def-stream-method open-stream-p ((stream socket-stream)))
+
+(def-stream-method close ((stream socket-stream)
+                          &key abort))
+
+(def-stream-method stream-pathname ((stream socket-stream)))
+
+(def-stream-method stream-truename ((stream socket-stream)))
+
+(def-stream-method stream-read-char ((stream socket-stream)))
+
+(def-stream-method stream-unread-char ((stream socket-stream)
+                                       character))
+
+(def-stream-method stream-read-char-no-hang
+    ((stream socket-stream)))
+
+(def-stream-method stream-peek-char ((stream socket-stream)))
+
+(def-stream-method stream-listen ((stream socket-stream)))
+
+(def-stream-method stream-read-line ((stream socket-stream)))
+
+(def-stream-method stream-clear-input ((stream socket-stream)))
+
+(def-stream-method stream-write-char
+    ((stream socket-stream)
+     character))
+
+(def-stream-method stream-line-column ((stream socket-stream)))
+
+(def-stream-method stream-start-line-p
+    ((stream socket-stream)))
+
+(def-stream-method stream-write-string ((stream socket-stream) string &optional start end))
+
+(defmethod stream-write-string :before  ((stream socket-stream) string &optional start end)
+  (declare (ignore start end))
+  (format t "~&STREAM-WRITE-STRING to SOCKET-STREAM.~%~tSTREAM: ~s~%~tINTERNAL STREAM: ~S~%~tSTRING: ~S~%" stream (socket-stream-stream stream) string))
+
+(def-stream-method stream-write-sequence ((stream socket-stream) sequence &optional start end))
+
+(defmethod stream-write-sequence :before  ((stream socket-stream) string &optional start end)
+  (declare (ignore start end string))
+  (format t "~&STREAM-WRITE-SEQENCE to SOCKET-STREAM.~%~tSTREAM: ~s~%~tINTERNAL STREAM: ~S~%" stream (socket-stream-stream stream)))
+
+
+(def-stream-method stream-terpri ((stream socket-stream)))
+
+(def-stream-method stream-fresh-line ((stream socket-stream)))
+
+(def-stream-method stream-finish-output
+    ((stream socket-stream)))
+
+(def-stream-method stream-force-output
+    ((stream socket-stream)))
+
+(def-stream-method stream-clear-output
+    ((stream socket-stream)))
+
+(def-stream-method stream-advance-to-column
+    ((stream socket-stream) column))
+
+(def-stream-method stream-read-byte ((stream socket-stream)))
+
+(def-stream-method stream-write-byte ((stream socket-stream) integer))
+
+;;; STREAM-LINE-LENGTH is a CMUCL extension to Gray Streams which the
+;;; pretty printer seems to use. There's a default method which works
+;;; for most CLIM streams. For several dumb reasons it doesn't work on
+;;; encapsulating streams.
+#+CMU
+(defmethod ext:stream-line-length ((stream socket-stream))
+  nil)
+#+SBCL
+(defmethod sb-gray:stream-line-length ((stream socket-stream))
+  nil)
+
+;;; Socket methods
+(defgeneric remote-host (socket-or-stream))
+(defgeneric remote-port (socket-or-stream))
+(defgeneric local-host (socket-or-stream))
+(defgeneric local-port (socket-or-stream))
+
+(defmethod remote-host ((socket sb-bsd-sockets:inet-socket))
+  (let ((addr (socket-peername socket)))
+    (format t "~&Trying to decode socket peername ~s~%" addr)
+     (vector-to-ipaddr addr)))
+
+(defmethod remote-port ((socket sb-bsd-sockets:inet-socket))
+  (let ((raw-port
+          (nth-value 1 (socket-peername socket))))
+    (etypecase raw-port
+      (fixnum raw-port)
+      ;; should error if we can't read an integer
+      (string (coerce (parse-integer raw-port :junk-allowed nil) 'fixnum)))))
+
+(defmethod local-port ((socket sb-bsd-sockets:inet-socket))
+  (let ((raw-port
+          (nth-value 1 (sb-bsd-sockets:socket-name socket))))
+    (etypecase raw-port
+      (fixnum raw-port)
+      ;; should error if we can't read an integer
+      (string (coerce (parse-integer raw-port :junk-allowed nil) 'fixnum)))))
+
+(def-socket-method remote-host ((stream socket-stream)))
+(def-socket-method remote-port ((stream socket-stream)))
+(def-socket-method local-host ((stream socket-stream)))
+(def-socket-method local-port ((stream socket-stream)))
+
+
+;;; WRAP FD STREAMS
+(defmethod stream-read-char ((stream sb-sys:fd-stream))
+  (read-char stream nil :eof))
+
+(defmethod stream-unread-char ((stream sb-sys:fd-stream) character)
+  (unread-char character stream)
+  nil)
+
+(defmethod stream-read-char-no-hang ((stream sb-sys:fd-stream))
+  (read-char-no-hang stream))
+
+(defmethod stream-peek-char ((stream sb-sys:fd-stream))
+  (peek-char nil stream nil :eof))
+
+(defmethod stream-listen ((stream sb-sys:fd-stream))
+  (listen stream))
+
+(defmethod stream-read-line ((stream sb-sys:fd-stream))
+  (read-line stream nil t))
+
+(defmethod stream-clear-input ((stream sb-sys:fd-stream))
+  (clear-input stream))
+
+(defmethod stream-write-char ((stream sb-sys:fd-stream) character)
+  (write-char character stream))
+
+(defmethod stream-line-column ((stream sb-sys:fd-stream))
+  (declare (ignorable stream))
+  nil)
+
+(defmethod stream-start-line-p ((stream sb-sys:fd-stream))
+  (declare (ignorable stream))
+  nil)
+
+(defmethod stream-write-string ((stream sb-sys:fd-stream) string &optional start end)
+  (write-string string stream :start start :end end))
+
+(defmethod stream-write-string :before ((stream sb-sys:fd-stream) string &optional start end)
+  (declare (ignore start end))
+  (format t "~&STREAM-WRITE-STRING to SB-SYS:FD-STREAM.~%~tSTREAM: ~s~%~tSTRING: ~S~%" stream string))
+
+(defmethod stream-write-sequence ((stream sb-sys:fd-stream) string &optional start end)
+  (write-sequence string stream :start start :end end))
+
+(defmethod stream-terpri ((stream sb-sys:fd-stream))
+  (terpri stream))
+
+(defmethod stream-fresh-line ((stream sb-sys:fd-stream))
+  (fresh-line stream))
+
+(defmethod stream-finish-output  ((stream sb-sys:fd-stream))
+  (finish-output stream))
+
+(defmethod stream-force-output ((stream sb-sys:fd-stream))
+  (force-output stream))
+
+(defmethod stream-clear-output ((stream sb-sys:fd-stream))
+  (clear-output stream))
+
+(defmethod stream-advance-to-column ((stream sb-sys:fd-stream) column)
+  (declare (ignorable stream) (ignore column))
+  nil)
+
+(defmethod stream-read-byte ((stream sb-sys:fd-stream))
+  (read-byte stream nil :eof))
+
+(defmethod stream-write-byte ((stream sb-sys:fd-stream) integer)
+  (write-byte integer stream))


### PR DESCRIPTION
A number of fixes to ACL-COMPAT sockets and multiprocessing in this MR.

The socket implementations were widely divergent, because ACL and CCL both implement open sockets (as opposed to listening sockets) as streams, but SBCL implements them as FD-STREAMS which are kind of primitive and difficult to work with.

There were also a number of issues in the way multiprocessing was handled on CCL and SBCL.  ACL-COMPAT just imported CCL's version of `process-wait-with-timeout`, even though its timeout units were different.  Made CCL consistent with other lisps.  SBCL's `process-wait-with-timeout` was buggy in a way I still don't understand. I reimplemented it using SBCL's `with-deadline` and it now works smoothly.

Other improvements along the way, such as removing top level imports and exports in favor of localizing all imports and exports in `defpackage`.